### PR TITLE
Bugfix: BaseUriProvider is compatible with Flow 6.3.2

### DIFF
--- a/Classes/Service/BaseUriProvider.php
+++ b/Classes/Service/BaseUriProvider.php
@@ -5,6 +5,7 @@ use Neos\Flow\Annotations as Flow;
 use GuzzleHttp\Psr7\Uri;
 use Neos\Flow\Http\BaseUriProvider as FlowBaseUriProvider;
 use Psr\Http\Message\UriInterface;
+use Psr\Http\Message\ServerRequestInterface;
 
 /**
  * Class BaseUriProvider
@@ -17,7 +18,7 @@ class BaseUriProvider extends  FlowBaseUriProvider
      *
      * @return UriInterface
      */
-    public function getConfiguredBaseUriOrFallbackToCurrentRequest(): UriInterface
+    public function getConfiguredBaseUriOrFallbackToCurrentRequest(ServerRequestInterface $fallbackRequest = null): UriInterface
     {
         return new Uri('https://domain.tld');
     }

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
         }
     ],
     "require": {
-        "neos/neos": "~5.0 || dev-master"
+        "neos/neos": "~5.0 || dev-master",
+        "neos/flow": ">=6.3.2 || dev-master"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
In Neos Flow 6.3.2 (see [ChangeLog](https://flowframework.readthedocs.io/en/6.3/TheDefinitiveGuide/PartV/ChangeLogs/632.html#id12)) the BaseUriProvider was changed which causes a php error regarding incompatible method declaration. This PR fixes the incompatibility.
