### PR TITLE
fix: Skip Postprocessor if NodeType is not defined (Fallback-Node)

### DIFF
--- a/Classes/NodeTypePostprocessor/IntegratorHelpMessagePostprocessor.php
+++ b/Classes/NodeTypePostprocessor/IntegratorHelpMessagePostprocessor.php
@@ -23,7 +23,7 @@ class IntegratorHelpMessagePostprocessor implements NodeTypePostprocessorInterfa
         }
 
         foreach ($configuration['properties'] as $propertyName => &$propertyConfiguration) {
-            if (isset($propertyConfiguration['ui'])) {
+            if (isset($propertyConfiguration['ui']) && isset($propertyConfiguration['type'])) {
                 $propertyConfiguration['ui']['help']['message'] = 'property: ' . $propertyName .' ,type: ' . $propertyConfiguration['type'];
             }
         }


### PR DESCRIPTION
Threw an error before when a missing NodeType (Neos FallbackNode) was present. 
```Could not convert target type "Neos\ContentRepository\Domain\Model\NodeInterface": Notice: Undefined index: type ...```